### PR TITLE
Additions for substitutions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,8 @@ release = '2021'
 # substitutions
 
 rst_prolog = """
-.. |short_name| replace:: Lib Name
-.. |full_name| replace:: Open Source Library Name
+.. include:: /subst_common.txt
+.. include:: /subst_specific.txt
 """
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/subst_specific.txt
+++ b/docs/source/subst_specific.txt
@@ -1,0 +1,2 @@
+.. |short_name| replace:: Lib Name
+.. |full_name| replace:: Open Source Library Name


### PR DESCRIPTION
Katya, I added two files for inclusion of common substitutions and specific substitutions. We could just have one include file, but this is the most flexible and would not require a change on the internal repo for cases where you change a substitution that is common to both repos. This involves then a change to the conf.py file to include these files into the rst_prolog.